### PR TITLE
Switch from `module` to `plugin` decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A DNS lookup plugin for Sopel IRC bots
 
 ## Requirements
 
-* Sopel 7.0+
+* Sopel 7.1+
 * `dnspython` 2.x
 * Python 3.6+
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find:
 zip_safe = false
 include_package_data = true
 install_requires =
-    sopel>=7.1,<8
+    sopel>=7.1,<9
     dnspython>=2.0,<3
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find:
 zip_safe = false
 include_package_data = true
 install_requires =
-    sopel>=7.0,<8
+    sopel>=7.1,<8
     dnspython>=2.0,<3
 
 [options.entry_points]

--- a/sopel_dns/__init__.py
+++ b/sopel_dns/__init__.py
@@ -10,7 +10,7 @@ import time
 import dns.resolver
 import requests
 
-from sopel import module
+from sopel import plugin
 
 ONELINE_RDTYPES = [
     'A',
@@ -26,12 +26,12 @@ MULTILINE_RDTYPES = [
 IMPLEMENTED_RDTYPES = ONELINE_RDTYPES + MULTILINE_RDTYPES
 
 
-@module.commands('dns')
-@module.example('.dns 1.2.3.4 PTR', user_help=True)
-@module.example('.dns domain.tld AAAA', user_help=True)
-@module.example('.dns domain.tld', user_help=True)
-@module.output_prefix('[dns] ')
-@module.rate(user=120)
+@plugin.commands('dns')
+@plugin.example('.dns 1.2.3.4 PTR', user_help=True)
+@plugin.example('.dns domain.tld AAAA', user_help=True)
+@plugin.example('.dns domain.tld', user_help=True)
+@plugin.output_prefix('[dns] ')
+@plugin.rate(user=120)
 def get_dnsinfo(bot, trigger):
     """Look up DNS information."""
     domain = trigger.group(3)
@@ -40,7 +40,7 @@ def get_dnsinfo(bot, trigger):
 
     if rdtype not in IMPLEMENTED_RDTYPES:
         bot.reply("I don't know how to show {} records yet.".format(rdtype))
-        return module.NOLIMIT
+        return plugin.NOLIMIT
 
     responses = []
 
@@ -55,13 +55,13 @@ def get_dnsinfo(bot, trigger):
             bot.reply("PTR record lookup is only supported for IP addresses.")
         else:
             bot.reply("That domain name doesn't seem to be valid.")
-        return module.NOLIMIT
+        return plugin.NOLIMIT
     except dns.exception.Timeout:
         bot.say("DNS lookup timed out for {}.".format(domain))
-        return module.NOLIMIT
+        return plugin.NOLIMIT
     except dns.resolver.NoNameservers:
         bot.say("DNS lookup attempted, but no nameservers were available.")
-        return module.NOLIMIT
+        return plugin.NOLIMIT
     except dns.resolver.NXDOMAIN:
         bot.say("DNS lookup returned NXDOMAIN for {}.".format(domain))
         return  # do rate-limit, since query succeeded


### PR DESCRIPTION
Sopel 8.0 will deprecate the old `sopel.module` namespace.

The replacement, `sopel.plugin`, was added in 7.1, so this plugin's minimum supported Sopel version must be increased from 7.0 -> 7.1. However, that shouldn't be a problem; 7.1 has been out since 2021.